### PR TITLE
allow unlimited time for us3iab-node jobs

### DIFF
--- a/class/submit_local.php
+++ b/class/submit_local.php
@@ -274,7 +274,7 @@ elog2( "create slurm cluster $cluster clusname $clusname quename $quename" );
       $slupath = $slufile;
       $wall    = $this->maxwall() * 3.0;
       if ( $is_us3iab )
-         $wall    = 2880.0;
+         $wall    = 999999;
       $nodes   = $this->nodes() * $mgroupcount;
 
       $hours   = (int)( $wall / 60 );
@@ -367,7 +367,9 @@ $this->message[] = "cluster=$cluster  ppn=$ppn  ppbj=$ppbj  wall=$wall";
           $libpath  = "/usr/local/lib64:/export/home/us3/cluster/lib:/usr/lib64/openmpi-1.10/lib:/opt/qt/lib";
           $path     = "/export/home/us3/cluster/bin:/usr/lib64/openmpi-1.10/bin";
           $ppn      = max( $ppn, 8 );
-          $wall     = 2880;
+          $wall     = 0; // no time limit
+          $walltime = "00:00:00";
+          $wallmins = 999999; // arbitrary limit for mpirun (~2 years!)
           break;
 
         default:


### PR DESCRIPTION
This seems to work for arbitrary time limits for us3iab-node*
the $wall=999999 is ~2 years, and is used as a parameter to mpirun us_mpi_analysis -walltime
I did *not* dig into the us_mpi_analysis code to see what the effect of this parameter.
SBATCH -t 00:00:00 sets max time to be the queue limit (currently INFINITE for usiab slurm installs).

Tested successfully on my Jetstream test instance.
