### PR TITLE
Remove UTHSCSA from copyright notice

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -25,7 +25,7 @@ echo<<<HTML
 	</div>
 
 	  <div id='info2'><hr />Last modified on $modtime --
-         <a href='license.php'>Copyright &copy; notice and license information</a> UltraScan Project, UTHSCSA
+         <a href='license.php'>Copyright &copy; notice and license information</a> UltraScan Project
       </div>
  
   </div>


### PR DESCRIPTION
This pull request makes a minor update to the copyright notice in the `footer.php` file, removing the reference to "UTHSCSA" from the UltraScan Project attribution.